### PR TITLE
Feat/delete access ticket

### DIFF
--- a/src/usecases/access-tickets/delete-access-ticket.test.ts
+++ b/src/usecases/access-tickets/delete-access-ticket.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment node
+ */
+import { deleteAccessTicketUseCase } from "@/usecases/access-tickets/delete-access-ticket";
+import { AccessTicketModel } from "@/domain/models/access-ticket";
+import { IAccessTicketRepository } from "@/infrastructure/repositories/interfaces/access-ticket-repository.interface";
+import { mapEntityToModel } from "@/mappers/access-ticket-mapper";
+
+// Mock dependencies
+jest.mock("@/mappers/access-ticket-mapper", () => ({
+  mapEntityToModel: jest.fn(),
+}));
+
+describe('deleteAccessTicketUseCase', () => {
+  // Define the repository mock
+  const mockRepo: jest.Mocked<IAccessTicketRepository> = {
+    findById: jest.fn(),
+    delete: jest.fn(),
+    insert: jest.fn(),
+    insertMany: jest.fn(),
+    findMany: jest.fn(),
+    findOne:  jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockMapEntityToModel = mapEntityToModel as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return undefined if the access ticket is not found', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+
+    const result = await deleteAccessTicketUseCase({ repo: mockRepo }, { id: '123' });
+
+    expect(mockRepo.findById).toHaveBeenCalledWith('123');
+    expect(mockRepo.delete).not.toHaveBeenCalled();
+    expect(mockMapEntityToModel).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it('should delete the access ticket and return the mapped model if found', async () => {
+    const entity = { id: '123', shlink_id: '123'}; // Mock entity
+    const model = new AccessTicketModel('123'); // Mock model
+
+    mockRepo.findById.mockResolvedValue(entity);
+    mockMapEntityToModel.mockReturnValue(model);
+
+    const result = await deleteAccessTicketUseCase({ repo: mockRepo }, { id: '123' });
+
+    expect(mockRepo.findById).toHaveBeenCalledWith('123');
+    expect(mockRepo.delete).toHaveBeenCalledWith(entity);
+    expect(mockMapEntityToModel).toHaveBeenCalledWith(entity);
+    expect(result).toEqual(model);
+  });
+});

--- a/src/usecases/access-tickets/delete-access-ticket.ts
+++ b/src/usecases/access-tickets/delete-access-ticket.ts
@@ -1,0 +1,12 @@
+import { AccessTicketModel } from "@/domain/models/access-ticket";
+import { IAccessTicketRepository } from "@/infrastructure/repositories/interfaces/access-ticket-repository.interface";
+import { mapEntityToModel } from "@/mappers/access-ticket-mapper";
+
+export const deleteAccessTicketUseCase = async (context: {repo: IAccessTicketRepository}, data: {id: string}): Promise<AccessTicketModel | undefined> => {
+    const entity = await context.repo.findById(data.id);
+
+    if(!entity) return;
+
+    await context.repo.delete(entity);
+    return mapEntityToModel(entity);
+}

--- a/src/usecases/access-tickets/delete-access-ticket.ts
+++ b/src/usecases/access-tickets/delete-access-ticket.ts
@@ -5,7 +5,7 @@ import { mapEntityToModel } from "@/mappers/access-ticket-mapper";
 export const deleteAccessTicketUseCase = async (context: {repo: IAccessTicketRepository}, data: {id: string}): Promise<AccessTicketModel | undefined> => {
     const entity = await context.repo.findById(data.id);
 
-    if(!entity) return;
+    if(!entity) return undefined;
 
     await context.repo.delete(entity);
     return mapEntityToModel(entity);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a delayed deletion mechanism for access tickets, enhancing ticket management by automatically removing them after 60 seconds.
	- Added a new use case for deleting access tickets, allowing for improved handling of ticket deletions.

- **Bug Fixes**
	- Implemented unit tests for the access ticket deletion functionality, ensuring robust error handling and correct deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->