### PR TITLE
fix: getServerSession function response data and data typing

### DIFF
--- a/src/app/api/auth/authOptions.ts
+++ b/src/app/api/auth/authOptions.ts
@@ -21,7 +21,7 @@ export const authOptions: AuthOptions = {
   ],
   callbacks: {
     session: async ({ session, token }) => {
-      return { ...session, user: token.user };
+      return { ...session, token: token, user: session.user };
     },
   },
 };

--- a/src/app/api/auth/authOptions.ts
+++ b/src/app/api/auth/authOptions.ts
@@ -21,7 +21,22 @@ export const authOptions: AuthOptions = {
   ],
   callbacks: {
     session: async ({ session, token }) => {
-      return { ...session, token };
+      return { ...session, ...token };
+    },
+    jwt: (params) => {
+      const tokenParam = params['token'];
+      if (tokenParam?.['token']) {
+        const { user = {}, token = {}, account = {} } = tokenParam;
+
+        return {
+          user,
+          token,
+          account: {
+            access_token: account['access_token'],
+          },
+        };
+      }
+      return params;
     },
   },
 };

--- a/src/app/api/auth/authOptions.ts
+++ b/src/app/api/auth/authOptions.ts
@@ -21,7 +21,7 @@ export const authOptions: AuthOptions = {
   ],
   callbacks: {
     session: async ({ session, token }) => {
-      return { ...session, token: token, user: session.user };
+      return { ...session, user: session.user, token };
     },
   },
 };

--- a/src/app/api/auth/authOptions.ts
+++ b/src/app/api/auth/authOptions.ts
@@ -21,7 +21,7 @@ export const authOptions: AuthOptions = {
   ],
   callbacks: {
     session: async ({ session, token }) => {
-      return { ...session, user: session.user, token };
+      return { ...session, token };
     },
   },
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,17 +1,20 @@
-import { JWT } from 'next-auth/src/jwt';
+import 'next-auth';
 
 declare module 'next-auth' {
-  interface DefaultJWT {
-    name: string;
-    email: string;
-    sub: string;
-    iat: number;
-    exp: number;
-    jti: string;
-  }
-
   interface Session {
-    token: DefaultJWT | JWT;
+    user?: {
+      id?: string;
+      name?: string;
+      email?: string;
+    };
+    token?: {
+      name?: string;
+      email?: string;
+      sub?: string;
+    };
     expires?: string;
+    account?: {
+      access_token?: string;
+    };
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,17 @@
+import { JWT } from 'next-auth/src/jwt';
+
+declare module 'next-auth' {
+  interface DefaultJWT {
+    name: string;
+    email: string;
+    sub: string;
+    iat: number;
+    exp: number;
+    jti: string;
+  }
+
+  interface Session {
+    token: DefaultJWT | JWT;
+    expires?: string;
+  }
+}


### PR DESCRIPTION
### Description
The current getServerSession function response is not included the user data and the token data.

### Motivation
The expect behavior of this logic is to have a typed session as a response from the getServerSession function.

### Screenshot after the update
![image](https://github.com/user-attachments/assets/fff008a5-ba97-406f-8cbd-a8e6a23ee727) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced session management with a new structure that includes both user information and token data.
	- Introduced a custom `DefaultJWT` interface for better handling of JSON Web Tokens.

- **Improvements**
	- Updated `Session` interface to include a `token` property, optional `expires` property, and an `account` property for improved type safety and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->