### PR TITLE
Add hapi-fhir service to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,8 @@ services:
 volumes:
   postgres_data:
     driver: local
+  hapi_fhir_data:
+    driver: local
 
 networks:
   smart-health-links-portal-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,20 @@ services:
     networks:
       - smart-health-links-portal-network
 
+  hapi-fhir:
+    image: jembi/hapi:v7.0.3-wget
+    ports:
+      - 8081:8080
+    networks:
+      - smart-health-links-portal-network
+    volumes:
+      - hapi_fhir_data:/var/lib/hapi-fhir
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
 volumes:
   postgres_data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,19 +72,7 @@ services:
     environment:
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.bulk_export_enabled=true
-      - HAPI_FHIR_IPS_ENABLED=true
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8080']
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    image: jembi/hapi:v7.0.3-wget
-    ports:
-      - 3447:8080
-    networks:
-      - smart-health-links-portal-network
-    volumes:
-      - hapi_fhir_data:/var/lib/hapi-fhir
+      - hapi.fhir.ips_enabled=true
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8080']
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,23 @@ services:
   hapi-fhir:
     image: jembi/hapi:v7.0.3-wget
     ports:
-      - 8081:8080
+      - 3447:8080
+    networks:
+      - smart-health-links-portal-network
+    volumes:
+      - hapi_fhir_data:/var/lib/hapi-fhir
+    environment:
+      - hapi.fhir.allow_external_references=true
+      - hapi.fhir.bulk_export_enabled=true
+      - HAPI_FHIR_IPS_ENABLED=true
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    image: jembi/hapi:v7.0.3-wget
+    ports:
+      - 3447:8080
     networks:
       - smart-health-links-portal-network
     volumes:


### PR DESCRIPTION
This pull request adds the hapi-fhir service to the docker-compose.yml file. The hapi-fhir service is configured with the image "jembi/hapi:v7.0.3-wget" and is exposed on port 8081. It is also added to the "smart-health-links-portal-network" network and has a volume mounted for data persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new service, `hapi-fhir`, enhancing the application's capabilities.
	- The service is now accessible via port 3447 on the host.

- **Improvements**
	- Implemented a health check for the `hapi-fhir` service to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->