### PR TITLE
Integrate Patient Summary view with API

### DIFF
--- a/src/app/patient-summary/ErrorState.tsx
+++ b/src/app/patient-summary/ErrorState.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Box, Typography, Button } from '@mui/material';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { Box, Typography, Button } from '@mui/material';
+import React from 'react';
 
 interface ErrorStateProps {
   message: string;

--- a/src/app/patient-summary/ErrorState.tsx
+++ b/src/app/patient-summary/ErrorState.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Box, Typography, Button } from '@mui/material';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+
+interface ErrorStateProps {
+  message: string;
+}
+
+const ErrorState: React.FC<ErrorStateProps> = ({ message }) => {
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      height="100vh"
+      padding={2}
+    >
+      <ErrorOutlineIcon color="error" style={{ fontSize: 80 }} />
+      <Typography variant="subtitle1" align="center" marginTop={2}>
+        {message}
+      </Typography>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleRefresh}
+        style={{ marginTop: 16 }}
+      >
+        Refresh Page
+      </Button>
+    </Box>
+  );
+};
+
+export default ErrorState;

--- a/src/app/patient-summary/PatientSummarySkeleton.tsx
+++ b/src/app/patient-summary/PatientSummarySkeleton.tsx
@@ -1,0 +1,34 @@
+import Box from '@mui/material/Box';
+import Container from '@mui/material/Container';
+import Skeleton from '@mui/material/Skeleton';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import * as React from 'react';
+
+export default function PatientSummarySkeleton() {
+  return (
+    <Container maxWidth={false}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        paddingTop={8}
+        paddingBottom={8}
+      >
+        <Box sx={{ width: '100%' }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <Tabs value={0} variant="scrollable" scrollButtons="auto">
+              <Tab label={<Skeleton width={100} />} />
+              <Tab label={<Skeleton width={100} />} />
+              <Tab label={<Skeleton width={100} />} />
+            </Tabs>
+          </Box>
+          <Box sx={{ padding: 2 }}>
+            <Skeleton variant="rectangular" width="100%" height={400} />
+          </Box>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/src/app/patient-summary/page.tsx
+++ b/src/app/patient-summary/page.tsx
@@ -1,14 +1,15 @@
 'use client';
-import { useEffect, useState } from 'react';
 import { Container } from '@mui/material';
 import Box from '@mui/material/Box';
-import { useAuth } from '../context/AuthProvider';
-import { apiSharedLink } from '../utils/api.class';
+import { useEffect, useState } from 'react';
+
 import { TBundle } from '@/types/fhir.types';
 
 import PatientSummary from './components/PatientSummary';
-import PatientSummarySkeleton from './PatientSummarySkeleton';
 import ErrorState from './ErrorState';
+import PatientSummarySkeleton from './PatientSummarySkeleton';
+import { useAuth } from '../context/AuthProvider';
+import { apiSharedLink } from '../utils/api.class';
 
 export default function PatientSummaryPage() {
   const { user, isAuthenticated } = useAuth();

--- a/src/app/patient-summary/page.tsx
+++ b/src/app/patient-summary/page.tsx
@@ -1,12 +1,44 @@
+'use client';
+import { useEffect, useState } from 'react';
 import { Container } from '@mui/material';
 import Box from '@mui/material/Box';
-
+import { useAuth } from '../context/AuthProvider';
+import { apiSharedLink } from '../utils/api.class';
 import { TBundle } from '@/types/fhir.types';
 
 import PatientSummary from './components/PatientSummary';
-import fhirBundleJson from './sample/bundle.json';
+import PatientSummarySkeleton from './PatientSummarySkeleton';
+import ErrorState from './ErrorState';
 
 export default function PatientSummaryPage() {
+  const { user, isAuthenticated } = useAuth();
+  const [fhirBundle, setFhirBundle] = useState<TBundle | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await apiSharedLink.getPatientData(user.id);
+        setFhirBundle(response.data as TBundle);
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [isAuthenticated, user]);
+
+  if (loading) {
+    return <PatientSummarySkeleton />;
+  }
+
+  if (error) {
+    return <ErrorState message={error} />;
+  }
+
   return (
     <Container maxWidth={false}>
       <Box
@@ -17,7 +49,7 @@ export default function PatientSummaryPage() {
         paddingTop={8}
         paddingBottom={8}
       >
-        <PatientSummary fhirBundle={fhirBundleJson as TBundle} />
+        {fhirBundle && <PatientSummary fhirBundle={fhirBundle} />}
       </Box>
     </Container>
   );

--- a/src/app/utils/api.class.ts
+++ b/src/app/utils/api.class.ts
@@ -42,6 +42,12 @@ export class ApiSHLink extends BaseApi {
   async createLink(data: object) {
     return await this.create({ url: `/${EEndpoint.shareLinks}`, data });
   }
+
+  async getPatientData(userId: string) {
+    return await this.find({
+      url: `/users/${userId}/ips`,
+    });
+  }
 }
 
 instance.interceptors.response.use(


### PR DESCRIPTION
This PR updates the Patient Summary view to retrieve and display data dynamically from the API instead of using mockup data. The changes include:

- **Dynamic Data Fetching**: The PatientSummaryPage component now fetches patient data from the API using the `/api/v1/users/{{userId}}/ips` endpoint.
- **Loading State**: Introduced a PatientSummarySkeleton component to display a loading skeleton while data is being fetched.
- **Error Handling**: Added an ErrorState component to display error messages and a refresh button in case of data retrieval failures.

## How to Test

1. Navigate to the Patient Summary view.
2. Verify that the data is fetched from the API and displayed correctly.
3. Check the loading skeleton is shown while data is being fetched.
4. Simulate an error (e.g., by taking down HAPI FHIR container) and verify that the error message and refresh button are displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `ErrorState` component to display error messages with a refresh option.
	- Enhanced `PatientSummaryPage` to fetch patient data dynamically and handle loading and error states.

- **Bug Fixes**
	- Removed hardcoded sample data, ensuring the patient summary relies on real-time data fetching.

- **Documentation**
	- Updated method documentation for new data fetching functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->