### PR TITLE
feat: add link endpoint creation

### DIFF
--- a/src/app/utils/api.class.ts
+++ b/src/app/utils/api.class.ts
@@ -43,6 +43,15 @@ export class ApiSHLink extends BaseApi {
     return await this.create({ url: `/${EEndpoint.shareLinks}`, data });
   }
 
+  async createEndpoint(linkId: string) {
+    return await this.create({
+      url: `/${EEndpoint.shareLinks}/${linkId}/endpoints`,
+      data: {
+        urlPath: '/$summary',
+      },
+    });
+  }
+
   async deactivateLink(id: string) {
     return await this.delete({ url: `/share-links/${id}/deactivate` });
   }


### PR DESCRIPTION
This update includes :
- Submit creation dialog form with enter button.
- Send endpoint creation associated to the creation link.
- Handle the case where the endpoint is failed (Alert message is showed).
- Lock the creation button to avoid submitting accidentally the link creation more than one time.
![image](https://github.com/user-attachments/assets/52213a8b-ca51-41d9-83fb-a3c24886fdfb)