### PR TITLE
Removed authentication for get single share link endpoints. Added che…

### DIFF
--- a/src/app/api/v1/share-links/[id]/endpoints/[endpointId]/route.test.ts
+++ b/src/app/api/v1/share-links/[id]/endpoints/[endpointId]/route.test.ts
@@ -62,7 +62,10 @@ describe('GET /api/v1/share-links/[id]/endpoints/[endpointId]', () => {
     expect(response).toBeInstanceOf(NextResponse);
     expect(response.status).toBe(401);
     const responseBody = await response.json();
-    expect(responseBody).toEqual({ message: UNAUTHORIZED_REQUEST });
+    expect(responseBody).toEqual({
+      detail: UNAUTHORIZED_REQUEST,
+      error: 'AuthenticationError',
+    });
   });
 
   it('should return 404 if SHLink is not found', async () => {
@@ -91,7 +94,10 @@ describe('GET /api/v1/share-links/[id]/endpoints/[endpointId]', () => {
     expect(response).toBeInstanceOf(NextResponse);
     expect(response.status).toBe(401);
     const responseBody = await response.json();
-    expect(responseBody).toEqual({ message: UNAUTHORIZED_REQUEST });
+    expect(responseBody).toEqual({
+      detail: UNAUTHORIZED_REQUEST,
+      error: 'AuthenticationError',
+    });
   });
 
   it('should return 200 with patient data if everything is valid', async () => {
@@ -127,6 +133,9 @@ describe('GET /api/v1/share-links/[id]/endpoints/[endpointId]', () => {
     expect(response).toBeInstanceOf(NextResponse);
     expect(response.status).toBe(401);
     const responseBody = await response.json();
-    expect(responseBody).toEqual({ message: UNAUTHORIZED_REQUEST });
+    expect(responseBody).toEqual({
+      detail: UNAUTHORIZED_REQUEST,
+      error: 'AuthenticationError',
+    });
   });
 });

--- a/src/app/api/v1/share-links/[id]/endpoints/[endpointId]/route.ts
+++ b/src/app/api/v1/share-links/[id]/endpoints/[endpointId]/route.ts
@@ -5,6 +5,7 @@ import {
   NOT_FOUND,
   UNAUTHORIZED_REQUEST,
 } from '@/app/constants/http-constants';
+import { AuthenticationError } from '@/app/utils/authentication';
 import { handleApiValidationError } from '@/app/utils/error-handler';
 import {
   AccessTicketRepositoryToken,
@@ -73,16 +74,17 @@ export async function GET(
 
   try {
     unstable_noStore();
+    if (!ticketId) {
+      throw new AuthenticationError();
+    }
+
     const ticket: AccessTicketModel = await getAccessTicketUseCase(
       { repo: ticketRepo },
       ticketId,
     );
 
     if (!ticket || ticket.getSHLinkId() !== params.id) {
-      return NextResponse.json(
-        { message: UNAUTHORIZED_REQUEST },
-        { status: 401 },
-      );
+      throw new AuthenticationError();
     }
 
     const shlink = await getSingleSHLinkUseCase(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,9 @@ const isFrontendPathname = (pathname: string) =>
   FRONTEND_PATHNAMES.includes(pathname);
 
 const isIgnorePath = (method: HTTP_VERB, pathname: string) => {
-  return !!IGNORE_PATHS[method]?.find((x) => pathname.match(x));
+  return (
+    IGNORE_PATHS[method]?.some((regex: RegExp) => regex.test(pathname)) ?? false
+  );
 };
 
 export async function middleware(req: NextRequest) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,18 +3,32 @@ import { getToken } from 'next-auth/jwt';
 
 const FRONTEND_PATHNAMES = ['/', '/patient-summary', '/shared-links'];
 const REDIRECTION_PATHNAME = '/';
+const IGNORE_PATHS = {
+  POST: [/^\/api\/v1\/share-links\/([^/]+)/],
+  GET: [/^\/api\/v1\/share-links\/([^/]+)\/endpoints\/([^/]+)/],
+};
+
+type HTTP_VERB = 'GET' | 'POST' | 'DELETE' | 'PUT' | 'PATCH';
 
 const isApiPathname = (pathname: string) => pathname.startsWith('/api/v1/');
 const isFrontendPathname = (pathname: string) =>
   FRONTEND_PATHNAMES.includes(pathname);
 
+const isIgnorePath = (method: HTTP_VERB, pathname: string) => {
+  return !!IGNORE_PATHS[method]?.find((x) => pathname.match(x));
+};
+
 export async function middleware(req: NextRequest) {
   const token = await getToken({ req });
-  const { nextUrl, url } = req;
+  const { nextUrl, url, method } = req;
   const { pathname } = nextUrl;
 
   try {
     if (!token) {
+      if (isIgnorePath(method as HTTP_VERB, pathname)) {
+        return NextResponse.next();
+      }
+
       if (isApiPathname(pathname)) throw new Error();
 
       if (pathname !== REDIRECTION_PATHNAME && isFrontendPathname(pathname)) {


### PR DESCRIPTION
…ck for tokenid on get share-link-endpoint endpoint. Updated tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for unauthorized requests, providing detailed response structures.
	- Introduced a requirement for `ticketId` in requests, improving authentication checks.
	- Implemented a new middleware structure to selectively ignore token validation for specific API paths.

- **Bug Fixes**
	- Streamlined error handling by using exceptions for authentication failures instead of JSON responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->