### PR TITLE
fix: Refactor token flag condition to handle passcode in SHlinkViewer…

### DIFF
--- a/src/app/viewer/page.tsx
+++ b/src/app/viewer/page.tsx
@@ -121,7 +121,7 @@ export default function SHlinkViewer() {
       recipient: name,
     };
 
-    if (tokenData?.flag === 'P') {
+    if (tokenData?.flag.includes('P')) {
       requestBody.passcode = passcode;
     }
 


### PR DESCRIPTION
This pull request addresses an issue in the `SHLinkViewer `component where the condition for setting the `passcode `in the `requestBody `was not correctly implemented. The `flag `can have values 'L', 'P', or 'LP'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced form submission logic for accessing patient data, accommodating multiple flag values.
  
- **Bug Fixes**
	- Improved error handling to provide clearer messages regarding token validity and file presence.

- **Refactor**
	- Streamlined request body construction for form submissions, maintaining validation for required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->