### PR TITLE
Update AddLinkDialog component to set minimum expiration date

### DIFF
--- a/src/app/shared-links/Components/dialogs/AddLinkDialog.tsx
+++ b/src/app/shared-links/Components/dialogs/AddLinkDialog.tsx
@@ -122,6 +122,9 @@ export const AddLinkDialog: FC<AddLinkDialogProps> = ({
               type="date"
               label="Expiration Date"
               InputLabelProps={{ shrink: true }}
+              InputProps={{
+                inputProps: { min: new Date().toISOString().split('T')[0] },
+              }}
               {...register('configExp', {
                 setValueAs: (value) => value || undefined,
               })}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a minimum date restriction for the "Expiration Date" field in the Add Link dialog, ensuring users cannot select past dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->